### PR TITLE
Fix for #13 "Spinner up/down click cannot update ViewModel in real-time" 

### DIFF
--- a/spec/spinner.spec.js
+++ b/spec/spinner.spec.js
@@ -39,17 +39,39 @@
         it('should write the widget\'s value to the viewmodel\'s bound property when it changes.', function () {
             var $element, vm;
 
-            $element = $('<div data-bind="spinner: { value: value }"></div>').appendTo('body');
+            $element = $('<input data-bind="spinner: { value: value }"></input>').appendTo('body');
+            
             vm = { value: ko.observable(1) };
             ko.applyBindings(vm, $element[0]);
 
             expect(vm.value.peek()).toEqual(1);
             $element.spinner('value', 55);
             expect(vm.value.peek()).toEqual(55);
+            $element.spinner('stepUp');
+            expect(vm.value.peek()).toEqual(56);
+            
+            // The spinner behaves a little bit differently than programmatically calling stepUp/stepDown when the user actually clicks up/down.
+            //
+            $element.focus().spinner("widget").find(".ui-spinner-up").mousedown().mouseup();
+            expect($element.spinner('value')).toEqual(57);
+            expect(vm.value.peek()).toEqual(56); // Focus is still on the input, so the spinner hasn't fired spinchange yet.
+            $element.blur().blur(); // Yes, the double blur is necessary.
+            expect(vm.value.peek()).toEqual(57); // *Now* the observable should be mutated.
 
             ko.removeNode($element[0]);
         });
 
+        it('should write the widget\'s value immediately to the viewmodel\'s bound property when it changes if "valueUpdate" binding is also used on the input.', function () {
+            var $element, vm;
+            
+            $element = $('<input data-bind="valueUpdate: \'afterkeydown\', spinner: { value: value }"></input>').appendTo('body');
+            
+            vm = { value: ko.observable(100) };
+            ko.applyBindings(vm, $element[0]);
+            $element.focus().spinner("widget").find(".ui-spinner-up").mousedown().mouseup();
+            expect(vm.value.peek()).toEqual(101);
+        });
+        
         it('should write the element to the widget observable', function () {
             var $element, vm, disabled;
 

--- a/src/spinner.js
+++ b/src/spinner.js
@@ -4,7 +4,7 @@
 
     var postInit;
 
-    postInit = function (element, valueAccessor) {
+    postInit = function (element, valueAccessor, allBindingsAccessor) {
         /// <summary>Keeps the value binding property in sync with the spinner's value.
         /// </summary>
         /// <param name='element' type='DOMNode'></param>
@@ -21,10 +21,26 @@
             });
         }
 
+        // If 'value' is an observable writeable, then add an event handler so that when the spinner 
+        // increments/decrements the 'value' observable can be mutated.  Which event we listen for depends
+        // upon if any of the KO valueUpdate options have been specified.  
+        // 1. When there is no valueUpdate in the binding, 'value' will be mutated in response to the 'spinchange' event
+        //    which occurs whenever the input loses focus.
+        // 2. If any of the KO valueUpdate options ("keyup", "keypress", "afterkeydown") are specified in the binding, 
+        //    this implies that you wish to mutate the 'value' observable in real-time. In this case the 'spin' event is 
+        //    used so that 'value' can be updated everytime there is an inc/dec, and done so immediately.
+        //
         if (ko.isWriteableObservable(value.value)) {
-            $(element).on('spinchange.ko', function () {
-                value.value($(element).spinner('value'));
-            });
+            if(allBindingsAccessor().valueUpdate) {
+                $(element).on('spin.ko', function(ev, ui) {
+                    value.value(ui.value);
+                });
+            }
+            else {
+                $(element).on('spinchange.ko', function () {
+                    value.value($(element).spinner('value'));
+                });
+            }
         }
 
         //handle disposal


### PR DESCRIPTION
Please consider this pull request to resolve #13 "Spinner up/down click cannot update ViewModel in real-time".  Jasmine unit tests are included as well, both to test the new functionality as well as some regression tests for the non real-time (default) functionality.
