### PR TITLE
Allow version numbers to only have 2 digits

### DIFF
--- a/src/versions.js
+++ b/src/versions.js
@@ -10,7 +10,7 @@ versions = (function () {
         /// <returns type='String'></returns>
 
         /*jslint regexp:true*/
-        var match = (version || '').match(/^(\d)\.(\d+)\..*$/);
+        var match = (version || '').match(/^(\d)\.(\d+)(\..*)?$/);
         /*jslint regexp:false*/
 
         if (!match) {


### PR DESCRIPTION
jQuery 1.7 fails version check because it's only got 2 digits.
