### PR TITLE
Fix demos loading via https

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <meta name="keywords" content="knockout,knockoutjs,jQuery UI,bindings,javascript" />
     <title>knockout-jqueryui</title>
     <link rel="stylesheet" href="css/styles.css" type="text/css" />
-    <link rel="stylesheet" href="http://code.jquery.com/ui/1.11.2/themes/pepper-grinder/jquery-ui.css" type="text/css" />
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.11.2/themes/pepper-grinder/jquery-ui.css" type="text/css" />
     <link rel="stylesheet" href="css/jasmine.css" type="text/css" />
     <!--[if lte IE 7]>
     <link rel="stylesheet" href="yaml/core/iehacks.min.css" type="text/css"/>
@@ -19,11 +19,11 @@
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
     {% raw %}
-    <script type="text/javascript" src="js/lib/version/version.js" data-param="jquery" data-url="http://code.jquery.com/jquery-{{VERSION}}.js"
+    <script type="text/javascript" src="js/lib/version/version.js" data-param="jquery" data-url="//code.jquery.com/jquery-{{VERSION}}.js"
         data-ver="1.11.2"></script>
-    <script type="text/javascript" src="js/lib/version/version.js" data-param="jqueryui" data-url="http://code.jquery.com/ui/{{VERSION}}/jquery-ui.js"
+    <script type="text/javascript" src="js/lib/version/version.js" data-param="jqueryui" data-url="//code.jquery.com/ui/{{VERSION}}/jquery-ui.js"
         data-ver="1.11.2"></script>
-    <script type="text/javascript" src="js/lib/version/version.js" data-param="knockout" data-url="http://knockoutjs.com/downloads/knockout-{{VERSION}}.debug.js"
+    <script type="text/javascript" src="js/lib/version/version.js" data-param="knockout" data-url="//cdnjs.cloudflare.com/ajax/libs/knockout/{{VERSION}}/knockout-debug.js"
         data-ver="3.2.0"></script>
     {% endraw %}
     <script type="text/javascript" src="js/lib/knockout-jqueryui/knockout-jqueryui.js"></script>


### PR DESCRIPTION
Currently when accessing https://gvas.github.io/knockout-jqueryui/accordion.html and other demo pages via HTTPS, knockout, jquery and jquery UI loading fails with [Mixed Content error](https://developer.mozilla.org/en/docs/Security/MixedContent)
