### PR TITLE
Add Knockout-jQueryUI to SystemJS registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ Build
     npm install
     grunt
 
+SystemJS
+-----
+Install
+```bash
+jspm install knockout-jqueryui
+```
+Usage
+```js
+System.import('knockout-jqueryui/datepicker');
+```
+
 Tests
 -----
 [http://gvas.github.com/knockout-jqueryui/tests.html](http://gvas.github.com/knockout-jqueryui/tests.html)


### PR DESCRIPTION
Congrats! Knockout-jQueryUI is now available from JSPM registry : 
http://kasperlewau.github.io/registry/#/?q=knockout-jqueryui

I suggest to inform peoples via readme file, what do you think ?